### PR TITLE
Add Support for Multiple Unix Package Managers in Grok Installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,136 +1,140 @@
-# Grok Terminal Chat
+Grok Terminal Chat
+A command-line interface for interacting with Grok AI in your terminal. Chat with Grok and execute system commands using natural language.
+Features
 
-A command-line interface for interacting with Grok AI in your terminal. This tool allows you to chat with Grok and execute system commands through natural language.
+Interactive chat with Grok AI
+Execute system commands via natural language
+Persistent conversation context
+Secure API key storage
+Easy installation and uninstallation
+Command history preservation
 
-## Features
+Supported Operating Systems
 
-- Interactive chat interface with Grok AI
-- Command execution through natural language
-- Conversation context maintenance
-- Secure API key storage
-- Easy installation and uninstallation
-- Command history preservation
+Debian-based (Ubuntu, Debian)
+Red Hat-based (Fedora, CentOS, RHEL, Amazon Linux 2/2023)
+Arch Linux
+openSUSE
+Alpine Linux
 
-## Prerequisites
+Prerequisites
 
-- Python 3
-- pip3
-- A Grok API key from x.ai
-- curl (for direct installation)
+Python 3.6 or higher
+pip3
+A Grok API key (obtain from xAI API)
+curl (for direct installation)
+sudo privileges for installation
 
-## Installation
+Installation
+Method 1: Direct Installation (Recommended)
+curl -fsSL https://raw.githubusercontent.com/lpolish/grok-terminal-chat/main/install.sh | sudo bash
 
-### Method 1: Direct Installation (Recommended)
+Then configure your API key:
+sudo grok --setup
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/lpolish/grok-terminal-chat/refs/heads/main/install.sh | bash
-```
+Method 2: Manual Installation
 
-After installation:
-```bash
-grok --setup  # Configure your API key
-```
+Clone the repository:
+git clone https://github.com/lpolish/grok-terminal-chat.git
+cd grok-terminal-chat
 
-### Method 2: Manual Installation
 
-1. Clone this repository:
-   ```bash
-   git clone [repository-url]
-   cd grokbash
-   ```
+Run the installer with sudo:
+sudo ./install.sh
 
-2. Run the installer:
-   ```bash
-   ./install.sh
-   ```
 
-3. Configure your API key:
-   ```bash
-   grok --setup
-   ```
+Configure your API key:
+sudo grok --setup
+
+
 
 The installer will:
-- Install required Python packages (openai)
-- Create necessary configuration directories
-- Install the `grok` command in `~/.local/bin`
 
-Make sure `~/.local/bin` is in your PATH. If it's not, add this to your `~/.bashrc`:
-```bash
-export PATH="$HOME/.local/bin:$PATH"
-```
+Install required system packages (Python, pip, virtualenv)
+Set up a Python virtual environment in /opt/grok_venv
+Install the grok command in /usr/local/bin
+Create configuration directories (/etc/grok_chat, /var/lib/grok)
 
-## Usage
-
-### Basic Commands
-
-```bash
+Usage
+Basic Commands
 grok              # Start the chat interface
 grok --help       # Show help message
 grok --setup      # Configure API key
-grok --rotate-key # Change API key
-grok --uninstall  # Remove the installation
-```
+grok --rotate-key # Update API key
+grok --uninstall  # Remove Grok
 
-### In Chat Commands
+In-Chat Commands
 
-- Type `exit` to quit
-- Type `clear` to reset conversation context
-- Press `Ctrl+C` to exit at any time
+exit: Quit the chat
+clear: Reset conversation context
+Ctrl+C: Exit immediately
 
-### Example Usage
-
-```bash
+Example
 $ grok
-Welcome to Grok Terminal Chat
+Grok Terminal Chat
 Type 'exit' to quit, 'clear' to reset context
-Press Ctrl+C to exit at any time
 
-You: list the files in the current directory
-Grok: I'll help you list the files in the current directory.
-EXECUTE: ls -l
-
+You: List files in the current directory
+Grok: EXECUTE: ls -l
 Command output:
-[files will be listed here]
-```
+total 8
+-rw-r--r-- 1 user user 1234 Apr 18 2025 file1.txt
+-rw-r--r-- 1 user user 5678 Apr 18 2025 file2.txt
 
-## Configuration
+Configuration
 
-- API Key: Stored in `~/.grok_chat/api_key`
-- Conversation Context: Stored in `~/.grok_conversation_context`
-- Configuration Directory: `~/.grok_chat/`
+API Key: Stored in /etc/grok_chat/api_key
+Conversation Context: Stored in /var/lib/grok/conversation_context
+Configuration Directory: /etc/grok_chat
 
-## Security
+Security
 
-- API key is stored with 600 permissions (user read/write only)
-- Configuration directory has 700 permissions (user access only)
-- All commands are shown before execution
-- Sensitive commands require explicit confirmation
+API key permissions: 600 (user read/write only)
+Configuration directory permissions: 700 (user access only)
+Commands are displayed before execution
+Sensitive commands require confirmation
 
-## Uninstallation
-
-To remove Grok Terminal Chat completely:
-
-```bash
-grok --uninstall
-```
+Uninstallation
+To remove Grok Terminal Chat:
+sudo grok --uninstall
 
 This will:
-- Remove the `grok` command
-- Delete all configuration files
-- Remove the conversation history
 
-## Troubleshooting
+Remove the grok command
+Delete configuration files and directories
+Remove the virtual environment
+Erase conversation history
 
-1. If `grok` command is not found:
-   - Ensure `~/.local/bin` is in your PATH
-   - Try running `source ~/.bashrc` or restart your terminal
+Troubleshooting
 
-2. If you get "API key not configured":
-   - Run `grok --setup` to configure your API key
+"grok: command not found":
 
-3. If Python packages are not found:
-   - Run `pip3 install --user openai` manually
+Ensure /usr/local/bin is in your PATH: export PATH=/usr/local/bin:$PATH
+Verify installation with ls /usr/local/bin/grok
 
-## Contributing
 
-Feel free to submit issues and enhancement requests!
+"API key not configured":
+
+Run sudo grok --setup to set your API key
+
+
+Package installation fails:
+
+Ensure internet connectivity
+For Alpine Linux, verify main and community repositories are enabled in /etc/apk/repositories
+Manually install Python: # Alpine: sudo apk add python3 py3-pip
+# Amazon Linux 2: sudo yum install python3 python3-pip
+
+
+
+
+Python package errors:
+
+Manually install the openai package: sudo /opt/grok_venv/bin/pip install openai
+
+
+
+Contributing
+Submit issues or pull requests at github.com/lpolish/grok-terminal-chat.
+License
+MIT License

--- a/README.md
+++ b/README.md
@@ -1,75 +1,90 @@
-Grok Terminal Chat
+# Grok Terminal Chat
+
 A command-line interface for interacting with Grok AI in your terminal. Chat with Grok and execute system commands using natural language.
-Features
 
-Interactive chat with Grok AI
-Execute system commands via natural language
-Persistent conversation context
-Secure API key storage
-Easy installation and uninstallation
-Command history preservation
+## Features
 
-Supported Operating Systems
+- Interactive chat with Grok AI
+- Execute system commands via natural language
+- Persistent conversation context
+- Secure API key storage
+- Easy installation and uninstallation
+- Command history preservation
 
-Debian-based (Ubuntu, Debian)
-Red Hat-based (Fedora, CentOS, RHEL, Amazon Linux 2/2023)
-Arch Linux
-openSUSE
-Alpine Linux
+## Supported Operating Systems
 
-Prerequisites
+- Debian-based (Ubuntu, Debian)
+- Red Hat-based (Fedora, CentOS, RHEL, Amazon Linux 2/2023)
+- Arch Linux
+- openSUSE
+- Alpine Linux
 
-Python 3.6 or higher
-pip3
-A Grok API key (obtain from xAI API)
-curl (for direct installation)
-sudo privileges for installation
+## Prerequisites
 
-Installation
-Method 1: Direct Installation (Recommended)
+- Python 3.6 or higher
+- pip3
+- A Grok API key (obtain from [xAI API](https://x.ai/api))
+- curl (for direct installation)
+- sudo privileges for installation
+
+## Installation
+
+### Method 1: Direct Installation (Recommended)
+
+```bash
 curl -fsSL https://raw.githubusercontent.com/lpolish/grok-terminal-chat/main/install.sh | sudo bash
+```
 
 Then configure your API key:
+```bash
 sudo grok --setup
+```
 
-Method 2: Manual Installation
+### Method 2: Manual Installation
 
-Clone the repository:
-git clone https://github.com/lpolish/grok-terminal-chat.git
-cd grok-terminal-chat
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/lpolish/grok-terminal-chat.git
+   cd grok-terminal-chat
+   ```
 
+2. Run the installer with sudo:
+   ```bash
+   sudo ./install.sh
+   ```
 
-Run the installer with sudo:
-sudo ./install.sh
-
-
-Configure your API key:
-sudo grok --setup
-
-
+3. Configure your API key:
+   ```bash
+   sudo grok --setup
+   ```
 
 The installer will:
+- Install required system packages (Python, pip, virtualenv)
+- Set up a Python virtual environment in `/opt/grok_venv`
+- Install the `grok` command in `/usr/local/bin`
+- Create configuration directories (`/etc/grok_chat`, `/var/lib/grok`)
 
-Install required system packages (Python, pip, virtualenv)
-Set up a Python virtual environment in /opt/grok_venv
-Install the grok command in /usr/local/bin
-Create configuration directories (/etc/grok_chat, /var/lib/grok)
+## Usage
 
-Usage
-Basic Commands
+### Basic Commands
+
+```bash
 grok              # Start the chat interface
 grok --help       # Show help message
 grok --setup      # Configure API key
 grok --rotate-key # Update API key
 grok --uninstall  # Remove Grok
+```
 
-In-Chat Commands
+### In-Chat Commands
 
-exit: Quit the chat
-clear: Reset conversation context
-Ctrl+C: Exit immediately
+- `exit`: Quit the chat
+- `clear`: Reset conversation context
+- `Ctrl+C`: Exit immediately
 
-Example
+### Example
+
+```bash
 $ grok
 Grok Terminal Chat
 Type 'exit' to quit, 'clear' to reset context
@@ -80,61 +95,60 @@ Command output:
 total 8
 -rw-r--r-- 1 user user 1234 Apr 18 2025 file1.txt
 -rw-r--r-- 1 user user 5678 Apr 18 2025 file2.txt
+```
 
-Configuration
+## Configuration
 
-API Key: Stored in /etc/grok_chat/api_key
-Conversation Context: Stored in /var/lib/grok/conversation_context
-Configuration Directory: /etc/grok_chat
+- **API Key**: Stored in `/etc/grok_chat/api_key`
+- **Conversation Context**: Stored in `/var/lib/grok/conversation_context`
+- **Configuration Directory**: `/etc/grok_chat`
 
-Security
+## Security
 
-API key permissions: 600 (user read/write only)
-Configuration directory permissions: 700 (user access only)
-Commands are displayed before execution
-Sensitive commands require confirmation
+- API key permissions: 600 (user read/write only)
+- Configuration directory permissions: 700 (user access only)
+- Commands are displayed before execution
+- Sensitive commands require confirmation
 
-Uninstallation
+## Uninstallation
+
 To remove Grok Terminal Chat:
+
+```bash
 sudo grok --uninstall
+```
 
 This will:
+- Remove the `grok` command
+- Delete configuration files and directories
+- Remove the virtual environment
+- Erase conversation history
 
-Remove the grok command
-Delete configuration files and directories
-Remove the virtual environment
-Erase conversation history
+## Troubleshooting
 
-Troubleshooting
+- **"grok: command not found"**:
+  - Ensure `/usr/local/bin` is in your PATH: `export PATH=/usr/local/bin:$PATH`
+  - Verify installation with `ls /usr/local/bin/grok`
 
-"grok: command not found":
+- **"API key not configured"**:
+  - Run `sudo grok --setup` to set your API key
 
-Ensure /usr/local/bin is in your PATH: export PATH=/usr/local/bin:$PATH
-Verify installation with ls /usr/local/bin/grok
+- **Package installation fails**:
+  - Ensure internet connectivity
+  - For Alpine Linux, verify `main` and `community` repositories are enabled in `/etc/apk/repositories`
+  - Manually install Python: 
+    ```bash
+    # Alpine: sudo apk add python3 py3-pip
+    # Amazon Linux 2: sudo yum install python3 python3-pip
+    ```
 
+- **Python package errors**:
+  - Manually install the `openai` package: `sudo /opt/grok_venv/bin/pip install openai`
 
-"API key not configured":
+## Contributing
 
-Run sudo grok --setup to set your API key
+Submit issues or pull requests at [github.com/lpolish/grok-terminal-chat](https://github.com/lpolish/grok-terminal-chat).
 
+## License
 
-Package installation fails:
-
-Ensure internet connectivity
-For Alpine Linux, verify main and community repositories are enabled in /etc/apk/repositories
-Manually install Python: # Alpine: sudo apk add python3 py3-pip
-# Amazon Linux 2: sudo yum install python3 python3-pip
-
-
-
-
-Python package errors:
-
-Manually install the openai package: sudo /opt/grok_venv/bin/pip install openai
-
-
-
-Contributing
-Submit issues or pull requests at github.com/lpolish/grok-terminal-chat.
-License
 MIT License

--- a/install.sh
+++ b/install.sh
@@ -43,16 +43,20 @@ safe_mkdir() {
 
 # Detect package manager
 detect_package_manager() {
-    if command -v apt-get >/dev/null; then
+    if command -v apk >/dev/null; then
+        echo "apk"
+    elif command -v apt-get >/dev/null; then
         echo "apt"
-    elif command -v dnf >/dev/null || command -v yum >/dev/null; then
+    elif command -v dnf >/dev/null; then
         echo "dnf"
+    elif command -v yum >/dev/null; then
+        echo "yum"
     elif command -v pacman >/dev/null; then
         echo "pacman"
     elif command -v zypper >/dev/null; then
         echo "zypper"
     else
-        fail "No supported package manager found (apt, dnf/yum, pacman, or zypper)"
+        fail "No supported package manager found (apk, apt, dnf, yum, pacman, or zypper)"
     fi
 }
 
@@ -69,6 +73,16 @@ install_system_deps() {
     debug_log "Detected package manager: $PKG_MANAGER"
 
     case "$PKG_MANAGER" in
+        apk)
+            debug_log "Updating package lists (apk)"
+            apk update || fail "Failed to update package lists"
+            debug_log "Installing core packages (apk)"
+            apk add \
+                python3 \
+                py3-pip \
+                python3-dev \
+                musl-dev || fail "Failed to install system packages"
+            ;;
         apt)
             debug_log "Updating package lists (apt)"
             apt-get update -q || fail "Failed to update package lists"
@@ -84,6 +98,15 @@ install_system_deps() {
             dnf update -y -q || fail "Failed to update package lists"
             debug_log "Installing core packages (dnf)"
             dnf install -y \
+                python3 \
+                python3-pip \
+                python3-virtualenv || fail "Failed to install system packages"
+            ;;
+        yum)
+            debug_log "Updating package lists (yum)"
+            yum update -y -q || fail "Failed to update package lists"
+            debug_log "Installing core packages (yum)"
+            yum install -y \
                 python3 \
                 python3-pip \
                 python3-virtualenv || fail "Failed to install system packages"


### PR DESCRIPTION
This commit enhances the Grok installer to support multiple Unix-based operating systems by adding compatibility with various package managers (apt, dnf/yum, pacman, zypper). The changes include:

    Introduced a detect_package_manager function to identify the system's package manager.
    Modified install_system_deps to handle package installation for apt, dnf, pacman, and zypper, ensuring appropriate Python dependencies are installed.
    Maintained existing functionality for Debian-based systems while extending support to Red Hat-based, Arch-based, and SUSE-based distributions.
    Updated error handling and debug logging to reflect the new package manager detection logic.

These changes make the installer more versatile, allowing Grok to be installed on a wider range of Unix-like systems.